### PR TITLE
Enhancement/decoration tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ export const Example = () => {
     // decorationTag - optional - {} or null
     // Wrapper Element for template
     // Null value prevents the template from being wrapped
-    // decorationTag.cssClasses - optional - Classes that will be added to the Wrapper Element
-    // decorationTag.tagname - optional - The type of Wrapper Element - e.g. div, section, etc
+    // decorationTag.cssClasses - optional - array - Array of classes that will be added to the Wrapper Element
+    // decorationTag.tagname - optional - string - The type of Wrapper Element - e.g. div, section, etc
     decorationTag: {
       cssClass: 'text',
       tagName: 'article'

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ export const Example = () => {
     // template - required
     // HTL/HTML File Reference or Inline HTML
     template: MyText, 
-    // decorationTag - optional -
+    // decorationTag - optional - {} or null
     // Wrapper Element for template
-    // decorationTag.cssClass - optional - Classes that will be added to the Wrapper Element
+    // Null value prevents the template from being wrapped
+    // decorationTag.cssClasses - optional - Classes that will be added to the Wrapper Element
     // decorationTag.tagname - optional - The type of Wrapper Element - e.g. div, section, etc
     decorationTag: {
       cssClass: 'text',

--- a/README.md
+++ b/README.md
@@ -39,3 +39,35 @@ To build and test out this project complete the following:
 - add configuration to specify runtime global vars
 - add configuration to specify runtime global name
 - add configuration to specify module import generator
+
+## Usage
+See [example](https://github.com/storybookjs/aem/blob/master/examples/aem-kitchen-sink/components/text/text.stories.js):
+```
+import Example from ('./example.html'); // HTL File or HTML File
+export const Example = () => {
+  return {
+    // content - optional 
+    // JSON Content TKTK Needs description, can be combined with Knobs
+    content: {
+      text: text('text', 'Hello, world.' ),
+      isRichText: boolean('isRichText', false),
+    },
+    // props - optional 
+    // JSON Content TKTK Needs description
+    props: {
+      'jcr:title': 'Text (v2)'
+    },
+    // template - required
+    // HTL/HTML File Reference or Inline HTML
+    template: MyText, 
+    // decorationTag - optional -
+    // Wrapper Element for template
+    // decorationTag.cssClass - optional - Classes that will be added to the Wrapper Element
+    // decorationTag.tagname - optional - The type of Wrapper Element - e.g. div, section, etc
+    decorationTag: {
+      cssClass: 'text',
+      tagName: 'article'
+    }
+  };
+};
+```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export const Example = () => {
     // decorationTag.cssClasses - optional - array - Array of classes that will be added to the Wrapper Element
     // decorationTag.tagname - optional - string - The type of Wrapper Element - e.g. div, section, etc
     decorationTag: {
-      cssClass: 'text',
+      cssClass: ['text'],
       tagName: 'article'
     }
   };

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -23,7 +23,7 @@ export default async function renderMain({
     `,
   };
   const storyObj = storyFn() as any;
-  const { resourceLoaderPath, template, props, content, wcmmode = {}, decorationTag = {}, noDecoration } = storyObj;
+  const { resourceLoaderPath, template, props, content, wcmmode = {}, decorationTag = {} } = storyObj;
   const runtime = new Runtime();
   runtime.setGlobal({
     wcmmode: wcmmode,
@@ -47,13 +47,13 @@ export default async function renderMain({
   });
 
   const decorationElementType = decorationTag.hasOwnProperty('tagName') ? decorationTag.tagName : 'div';
-  const decorationElementClass = decorationTag.hasOwnProperty('cssClass') ? decorationTag.cssClass : 'component'; 
+  const decorationElementClass = decorationTag.hasOwnProperty('cssClasses') ? decorationTag.cssClasses : 'component'; 
 
   const decorationElement = document.createElement(decorationElementType);
   decorationElement.setAttribute('class',decorationElementClass);
   
   if (typeof template === 'string') {
-    if (noDecoration) {
+    if (decorationTag === null) {
       rootElement.innerHTML = template;
     } else {
       rootElement.innerHTML = '';
@@ -73,7 +73,7 @@ export default async function renderMain({
       }
             
       rootElement.innerHTML = '';
-      if (noDecoration) {
+      if (decorationTag === null) {
         rootElement.appendChild(element);
       } else {
         decorationElement.appendChild(element);

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -47,7 +47,7 @@ export default async function renderMain({
   });
 
   const decorationElementType = decorationTag.hasOwnProperty('tagName') ? decorationTag.tagName : 'div';
-  const decorationElementClass = decorationTag.hasOwnProperty('cssClasses') ? decorationTag.cssClasses : 'component'; 
+  const decorationElementClass = decorationTag.hasOwnProperty('cssClasses') ? decorationTag.cssClasses.join(' ') : 'component';
 
   const decorationElement = document.createElement(decorationElementType);
   decorationElement.setAttribute('class',decorationElementClass);

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -15,8 +15,15 @@ export default async function renderMain({
   showError,
   forceRender,
 }: RenderMainArgs) {
+  const errorMessage = {
+    title: `Expecting an HTML snippet or DOM node from the story: "${selectedStory}" of "${selectedKind}".`,
+    description: dedent`
+      Did you forget to return the HTML snippet from the story in the template parameter?
+      Use "template: <your snippet, node, or template>" or when defining the story.
+    `,
+  };
   const storyObj = storyFn() as any;
-  const { resourceLoaderPath, template, props, content, wcmmode = {} } = storyObj;
+  const { resourceLoaderPath, template, props, content, wcmmode = {}, decorationTag = {}, noDecoration } = storyObj;
   const runtime = new Runtime();
   runtime.setGlobal({
     wcmmode: wcmmode,
@@ -38,26 +45,42 @@ export default async function renderMain({
   Object.entries(runtime.globals).forEach(([key, value]) => {
     (global as any)[key] = value;
   });
-  const element =  await template(runtime);
-  console.log('made it again')
 
-  if (typeof element === 'string') {
-    rootElement.innerHTML = element;
-  } else if (element instanceof Node) {
-    // Don't re-mount the element if it didn't change and neither did the story
-    if (rootElement.firstChild === element && forceRender === true) {
-      return;
+  const decorationElementType = decorationTag.hasOwnProperty('tagName') ? decorationTag.tagName : 'div';
+  const decorationElementClass = decorationTag.hasOwnProperty('cssClass') ? decorationTag.cssClass : 'component'; 
+
+  const decorationElement = document.createElement(decorationElementType);
+  decorationElement.setAttribute('class',decorationElementClass);
+  
+  if (typeof template === 'string') {
+    if (noDecoration) {
+      rootElement.innerHTML = template;
+    } else {
+      rootElement.innerHTML = '';
+      decorationElement.innerHTML = template;
+      rootElement.appendChild(decorationElement);
     }
-
-    rootElement.innerHTML = '';
-    rootElement.appendChild(element);
+  } else if (typeof template === 'function') {
+    const element = await template(runtime);
+    if (element instanceof Node !== true) {
+      showError(errorMessage);
+    } else {
+      // Don't re-mount the element if it didn't change and neither did the story
+      if (forceRender === true &&
+        (rootElement.firstChild === element ||
+        (rootElement.firstChild === decorationElement && decorationElement.firstChild === element) ) ) {
+        return;
+      }
+            
+      rootElement.innerHTML = '';
+      if (noDecoration) {
+        rootElement.appendChild(element);
+      } else {
+        decorationElement.appendChild(element);
+        rootElement.appendChild(decorationElement);
+      }
+    }
   } else {
-    showError({
-      title: `Expecting an HTML snippet or DOM node from the story: "${selectedStory}" of "${selectedKind}".`,
-      description: dedent`
-        Did you forget to return the HTML snippet from the story?
-        Use "() => <your snippet or node>" or when defining the story.
-      `,
-    });
+    showError(errorMessage);
   }
 }

--- a/app/aem/src/client/preview/types.ts
+++ b/app/aem/src/client/preview/types.ts
@@ -34,6 +34,6 @@ export interface StoryFnHtmlReturnType {
 }
 
 export interface DecorationTag { 
-  cssClasses?: string;
+  cssClasses?: string [];
   tagName?: string;
 }

--- a/app/aem/src/client/preview/types.ts
+++ b/app/aem/src/client/preview/types.ts
@@ -34,6 +34,6 @@ export interface StoryFnHtmlReturnType {
 }
 
 export interface DecorationTag { 
-  cssClass?: string;
+  cssClasses?: string;
   tagName?: string;
 }

--- a/app/aem/src/client/preview/types.ts
+++ b/app/aem/src/client/preview/types.ts
@@ -30,4 +30,10 @@ export interface StoryFnHtmlReturnType {
   resourceLoaderPath?: string;
   template?: any;
   wcmmode?: any;
+  decorationTag?: DecorationTag;
+}
+
+export interface DecorationTag { 
+  cssClass?: string;
+  tagName?: string;
 }

--- a/examples/aem-kitchen-sink/components/text/text.stories.js
+++ b/examples/aem-kitchen-sink/components/text/text.stories.js
@@ -23,7 +23,7 @@ export const Text = () => {
     },
     template: MyText,
     decorationTag: {
-      cssClass: 'text',
+      cssClasses: ['text','component'],
       tagName: 'article'
     }
   };

--- a/examples/aem-kitchen-sink/components/text/text.stories.js
+++ b/examples/aem-kitchen-sink/components/text/text.stories.js
@@ -22,6 +22,10 @@ export const Text = () => {
       'jcr:title': 'Text (v2)'
     },
     template: MyText,
+    decorationTag: {
+      cssClass: 'text',
+      tagName: 'article'
+    }
   };
 };
 
@@ -35,5 +39,6 @@ export const RichText = () => {
       'jcr:title': 'Text (v2)'
     },
     template: MyText,
+    noDecoration: true
   };
 };


### PR DESCRIPTION
Issue: Adding the Decoration Tag Wrapper Element around the template markup.

## What I did
Updated the render method to wrap the passed template in an element based on the passed configuration. Added example to the text stories. Updated the README with usage documentation.

## How to test
Open the Text story, See that there is an `<article class="text">` wrapping element around the Text story. And that there is none around the Rich Text story. Additionally, the other story examples should have a `<div class="component">` wrapper, as that is the default.

- Is this testable with Jest or Chromatic screenshots? Maybe?
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.
