### PR TITLE
fix(htl): use latest htlegine and revert workarounds

### DIFF
--- a/app/aem/package.json
+++ b/app/aem/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "htl-loader": "2.0.0",
-    "@adobe/htlengine": "4.1.1",
+    "@adobe/htlengine": "4.3.0",
     "@storybook/addons": "6.0.0-alpha.2",
     "@storybook/core": "6.0.0-alpha.2",
     "@storybook/client-api": "6.0.0-alpha.2",

--- a/app/aem/package.json
+++ b/app/aem/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "htl-loader": "2.0.0",
-    "@adobe/htlengine": "4.0.0",
+    "@adobe/htlengine": "4.1.1",
     "@storybook/addons": "6.0.0-alpha.2",
     "@storybook/core": "6.0.0-alpha.2",
     "@storybook/client-api": "6.0.0-alpha.2",

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -39,19 +39,13 @@ export default async function renderMain({
   }
 
   showMain();
-  
-  // todo: runtime globals are not available in templates
-  // see https://github.com/adobe/htlengine/issues/133
-  Object.entries(runtime.globals).forEach(([key, value]) => {
-    (global as any)[key] = value;
-  });
 
   const decorationElementType = decorationTag.hasOwnProperty('tagName') ? decorationTag.tagName : 'div';
   const decorationElementClass = decorationTag.hasOwnProperty('cssClasses') ? decorationTag.cssClasses.join(' ') : 'component';
 
   const decorationElement = document.createElement(decorationElementType);
   decorationElement.setAttribute('class',decorationElementClass);
-  
+
   if (typeof template === 'string') {
     if (decorationTag === null) {
       rootElement.innerHTML = template;
@@ -71,7 +65,7 @@ export default async function renderMain({
         (rootElement.firstChild === decorationElement && decorationElement.firstChild === element) ) ) {
         return;
       }
-            
+
       rootElement.innerHTML = '';
       if (decorationTag === null) {
         rootElement.appendChild(element);

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -32,7 +32,7 @@ export default async function renderMain({
     },
     content: content,
   });
-  runtime.withDomFactory(new Runtime.VDOMFactory(window.document.implementation));
+  runtime.withDomFactory(new Runtime.VDOMFactory(window.document.implementation).withKeepFragment(true));
   if(resourceLoaderPath && content) {
     const resolver = new ResourceResolver(content, new ComponentLoader());
     runtime.withResourceLoader(resolver.createResourceLoader(resourceLoaderPath));

--- a/examples/aem-kitchen-sink/components/accordion/accordion.html
+++ b/examples/aem-kitchen-sink/components/accordion/accordion.html
@@ -1,7 +1,3 @@
-<!--/* TODO:        data-cmp-expanded="${item.name in accordion.expandedItems}">*/-->
-<!--/* TODO:            <button class="cmp-accordion__button${item.name in accordion.expandedItems ? ' cmp-accordion__button&#45;&#45;expanded' : ''}"*/-->
-<!--/* TODO:             class="cmp-accordion__panel${item.name in accordion.expandedItems ? ' cmp-accordion__panel&#45;&#45;expanded' : ' cmp-accordion__panel&#45;&#45;hidden'}"*/-->
-<!--/* TODO: data-cmp-expanded="${accordion.expandedItems[item.name] ? true : false}"> */-->
 <div data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
      class="cmp-accordion"
      data-cmp-is="accordion"
@@ -10,10 +6,10 @@
          data-sly-repeat.item="${accordion.items}"
          class="cmp-accordion__item"
          data-cmp-hook-accordion="item"
-         data-cmp-expanded="true">
+         data-cmp-expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
             class="cmp-accordion__header">
-            <button class="cmp-accordion__button${accordion.expandedItems[item.name] ? ' cmp-accordion__button--expanded' : ''}"
+            <button class="cmp-accordion__button${item.name in accordion.expandedItems ? ' cmp-accordion__button--expanded' : ''}"
                     data-cmp-hook-accordion="button">
                 <span class="cmp-accordion__title">${item.title}</span>
                 <span class="cmp-accordion__icon"></span>
@@ -21,7 +17,7 @@
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
              data-cmp-hook-accordion="panel"
-             class="cmp-accordion__panel${accordion.expandedItems[item.name] ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
+             class="cmp-accordion__panel${item.name in accordion.expandedItems ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
              role="region"></div>
     </div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adobe/htlengine@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.1.1.tgz#259f3bd740f0563ecf660f2dd6a0c0f3f9a547a1"
-  integrity sha512-xADG2aLaRWpBaRJl21cmnaeMhDV/f8okGRI/Wu82OzKsTkNCUEao1hXEyOhiPlEq+T6AaKr3C6k7vNvC8EKWNg==
+"@adobe/htlengine@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.3.0.tgz#fd10240b667cf1ad0643912974c9f61edef3d216"
+  integrity sha512-t9YmYRXgfZv/b9jEUsVa/kOseXYm+2G8hD0yxAgWt0E0hkE66NXe0E2JZFXDnz7Cebx9wsn0Xm+1qJeealsKxQ==
   dependencies:
     antlr4 "^4.7.2"
     fs-extra "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,12 @@
 # yarn lockfile v1
 
 
-"@adobe/htlengine@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.0.0.tgz#8854d785929339f73e5dd0906acbe846b895a63c"
-  integrity sha512-9M3tTeoMK9KSkkUM8LmAa1q5jKG2G2f46rgIk0AS3PGk2H5Df1MT82HxxCmBlqTOLeH2EOVfb+UWBqAWaEY2Hg==
+"@adobe/htlengine@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.1.1.tgz#259f3bd740f0563ecf660f2dd6a0c0f3f9a547a1"
+  integrity sha512-xADG2aLaRWpBaRJl21cmnaeMhDV/f8okGRI/Wu82OzKsTkNCUEao1hXEyOhiPlEq+T6AaKr3C6k7vNvC8EKWNg==
   dependencies:
     antlr4 "^4.7.2"
-    co "^4.6.0"
     fs-extra "^8.0.0"
     he "^1.2.0"
     lodash "^4.17.15"
@@ -3516,11 +3515,6 @@ clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What I did
- updated the htlegine to version 4.3.0
- removed workarounds for global variables
- removed workaround for missing `in` and `data-sly-repeat`
- ensure that rendering keeps fragment (and does not create a body tag)

## How to test
- build and run
