### PR TITLE
Decoration Tag Support for dynamic CSS Classes

### DIFF
--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -65,7 +65,11 @@ const getDecorationElement = (decorationTag: DecorationTag, element: Element) =>
       decorationTag,
       PROPERTY_CSS_CLASSES
     )
-      ? decorationTag.cssClasses.join(' ')
+      ? decorationTag.cssClasses
+          .map((value: any) => {
+            return typeof value === 'function' ? value() : value;
+          })
+          .join(' ')
       : 'component';
     decorationElement = document.createElement(decorationElementType);
     decorationElement.setAttribute(ATTRIBUTE_CLASS, decorationElementClass);


### PR DESCRIPTION
## What I did
Updated the decoration tag to support functions as part of the passed array of classnames. This provides support for addons that add classnames

## How to test
View component decorator element, see classnames.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? Probably
- Does this need an update to the documentation? Probably

Will add new story and update documentation with issue #31  