### PR TITLE
Syncing build processes for npm install

### DIFF
--- a/app/aem/src/client/preview/helpers/ResourceResolver.ts
+++ b/app/aem/src/client/preview/helpers/ResourceResolver.ts
@@ -1,4 +1,4 @@
-import * as Runtime from '@adobe/htlengine/src/runtime/Runtime';
+import { default as Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
 import { window } from 'global';
 
 export default class ResourceResolver {
@@ -46,7 +46,7 @@ export default class ResourceResolver {
       // create a new runtime for this component
       const localRuntime = new Runtime()
         .withResourceLoader(this.createResourceLoader(path))
-        .withDomFactory(new Runtime.VDOMFactory(window.document.implementation))
+        .withDomFactory(new VDOMFactory(window.document.implementation))
         .setGlobal({
           ...runtime.globals,
           component: {

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -1,6 +1,6 @@
 /* eslint-disable valid-typeof */
 import { document, Node, window } from 'global';
-import * as Runtime from '@adobe/htlengine/src/runtime/Runtime';
+import { default as Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
 import { RenderMainArgs, ShowErrorArgs, DecorationTag, AemMetadata } from './types/types';
 import ComponentLoader from './helpers/ComponentLoader';
 import ResourceResolver from './helpers/ResourceResolver';
@@ -26,7 +26,7 @@ const createRuntime = (
   const components: any[] = aemMetadata ? aemMetadata.components : [];
   return new Runtime()
     .setGlobal({ models, wcmmode, component: { properties: {} }, content })
-    .withDomFactory(new Runtime.VDOMFactory(window.document.implementation).withKeepFragment(true))
+    .withDomFactory(new VDOMFactory(window.document.implementation).withKeepFragment(true))
     .withResourceLoader(
       new ResourceResolver(content || {}, new ComponentLoader(), components).createResourceLoader(
         resourceLoaderPath || '/'

--- a/scripts/compile-tsc.js
+++ b/scripts/compile-tsc.js
@@ -6,7 +6,7 @@ const shell = require('shelljs');
 function getCommand(watch) {
   const tsc = path.join(__dirname, '..', 'node_modules', '.bin', 'tsc');
 
-  const args = ['--outDir ./app/aem/dist', '--listEmittedFiles true'];
+  const args = [`--outDir ${path.join(__dirname, '..', 'app/aem/dist')}`, '--listEmittedFiles true', '--allowjs true'];
 
   if (watch) {
     args.push('-w');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "target": "es5",
     "types": ["jest"],
     "lib": ["es2017", "dom"],
-    "allowJs": true
+    "allowJs": true,
+    "rootDir": "./app/aem/src"
   },
   "exclude": [
     "**/dist",
@@ -23,6 +24,10 @@
     "**/node_modules",
     "**/*.spec.ts",
     "**/__tests__",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "examples",
+    "scripts",
+    "app/aem/bin",
+    "app/aem/standalone.js"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,28 +1480,6 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
-"@storybook/aem@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@storybook/aem/-/aem-0.0.2.tgz#9d350973f560976f9077d1770b6b9114317154c8"
-  integrity sha512-1vjXvlEWh1XYb64309CbuAnP1qVt6AnSUJ/BriBvvrRQyIQbKe47yJyoGUTWr+6WMK2iI8oPAxwKlOTZj6HI6w==
-  dependencies:
-    "@adobe/htlengine" "4.3.0"
-    "@storybook/addons" "6.0.0-alpha.2"
-    "@storybook/client-api" "6.0.0-alpha.2"
-    "@storybook/core" "6.0.0-alpha.2"
-    "@storybook/core-events" "6.0.0-alpha.2"
-    "@storybook/source-loader" "6.0.0-alpha.2"
-    "@types/webpack" "^4.41.3"
-    "@types/webpack-env" "^1.15.0"
-    babel-loader "^8.0.6"
-    core-js "^3.0.1"
-    global "^4.3.2"
-    htl-loader "2.0.0"
-    regenerator-runtime "^0.13.3"
-    typescript "^3.7.5"
-    webpack "^4.42.0"
-    xml2json "^0.12.0"
-
 "@storybook/api@6.0.0-alpha.2":
   version "6.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.0.0-alpha.2.tgz#de097ec556fd9e304bad0a5bd3ca0e7ca684e750"


### PR DESCRIPTION
Issue: npm install fails

## What I did
Updated Runtime to use named imports - they were breaking with using the default import. updated tsconfig to exclude files and make dist folder output the same from prepare and build scripts.

## How to test
Test yarn build and app/aem yarn prepare to ensure the same file structure is output to the dist folder. Also test app/aem npm pack to see the correct dist folder is packaged in the tgz file.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No