### PR TITLE
Simulating Page Load

### DIFF
--- a/app/aem/src/client/preview/helpers/ResourceResolver.ts
+++ b/app/aem/src/client/preview/helpers/ResourceResolver.ts
@@ -1,4 +1,7 @@
-import { Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
+// We need the default as Runtime,
+// or else the Runtime class doesn't get properly resolved
+/* eslint-disable import/no-named-default */
+import { default as Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
 import { window } from 'global';
 
 export default class ResourceResolver {

--- a/app/aem/src/client/preview/helpers/simulate-pageload.ts
+++ b/app/aem/src/client/preview/helpers/simulate-pageload.ts
@@ -21,7 +21,7 @@ const runScriptTypes = [
 ];
 
 // trigger DOMContentLoaded
-function simulateDOMContentLoaded() {
+export function simulateDOMContentLoaded() {
   const DOMContentLoadedEvent = document.createEvent('Event');
   DOMContentLoadedEvent.initEvent('DOMContentLoaded', true, true);
   document.dispatchEvent(DOMContentLoadedEvent);
@@ -92,5 +92,7 @@ export function simulatePageLoad($container) {
     // insert the script tags sequentially
     // to preserve execution order
     insertScriptsSequentially(scriptsToExecute, simulateDOMContentLoaded, undefined);
+  } else {
+    simulateDOMContentLoaded();
   }
 }

--- a/app/aem/src/client/preview/helpers/simulate-pageload.ts
+++ b/app/aem/src/client/preview/helpers/simulate-pageload.ts
@@ -20,6 +20,9 @@ const runScriptTypes = [
   'text/x-javascript',
 ];
 
+const SCRIPT = 'script';
+const SCRIPTS_ROOT_ID = 'scripts-root';
+
 // trigger DOMContentLoaded
 export function simulateDOMContentLoaded() {
   const DOMContentLoadedEvent = document.createEvent('Event');
@@ -67,15 +70,15 @@ function insertScriptsSequentially(scriptsToExecute, callback, index) {
 }
 
 export function simulatePageLoad($container) {
-  let $scriptsRoot = document.querySelector('#scripts-root');
+  let $scriptsRoot = document.querySelector(`#${SCRIPTS_ROOT_ID}`);
   if (!$scriptsRoot) {
     $scriptsRoot = document.createElement('div');
-    $scriptsRoot.id = 'scripts-root';
+    $scriptsRoot.id = SCRIPTS_ROOT_ID;
     document.body.appendChild($scriptsRoot);
   } else {
     $scriptsRoot.innerHTML = '';
   }
-  const $scripts = Array.from($container.querySelectorAll('script'));
+  const $scripts = Array.from($container.querySelectorAll(SCRIPT));
 
   if ($scripts.length) {
     const scriptsToExecute = [];

--- a/app/aem/src/client/preview/helpers/simulate-pageload.ts
+++ b/app/aem/src/client/preview/helpers/simulate-pageload.ts
@@ -1,0 +1,96 @@
+import { document } from 'global';
+
+// https://html.spec.whatwg.org/multipage/scripting.html
+const runScriptTypes = [
+  'application/javascript',
+  'application/ecmascript',
+  'application/x-ecmascript',
+  'application/x-javascript',
+  'text/ecmascript',
+  'text/javascript',
+  'text/javascript1.0',
+  'text/javascript1.1',
+  'text/javascript1.2',
+  'text/javascript1.3',
+  'text/javascript1.4',
+  'text/javascript1.5',
+  'text/jscript',
+  'text/livescript',
+  'text/x-ecmascript',
+  'text/x-javascript',
+];
+
+// trigger DOMContentLoaded
+function simulateDOMContentLoaded() {
+  const DOMContentLoadedEvent = document.createEvent('Event');
+  DOMContentLoadedEvent.initEvent('DOMContentLoaded', true, true);
+  document.dispatchEvent(DOMContentLoadedEvent);
+}
+
+function insertScript($script, callback, $scriptRoot) {
+  const scriptEl = document.createElement('script');
+  scriptEl.type = 'text/javascript';
+  if ($script.src) {
+    scriptEl.onload = callback;
+    scriptEl.onerror = callback;
+    scriptEl.src = $script.src;
+  } else {
+    scriptEl.textContent = $script.innerText;
+  }
+
+  // re-insert the script tag so it executes.
+  if ($scriptRoot) $scriptRoot.appendChild(scriptEl);
+  else document.head.appendChild(scriptEl);
+
+  // clean-up
+  $script.parentNode.removeChild($script);
+
+  // run the callback immediately for inline scripts
+  if (!$script.src) callback();
+}
+
+// runs an array of async functions in sequential order
+/* eslint-disable no-param-reassign, no-plusplus */
+function insertScriptsSequentially(scriptsToExecute, callback, index) {
+  if (typeof index === 'undefined') {
+    index = 0;
+  }
+
+  scriptsToExecute[index](() => {
+    index++;
+    if (index === scriptsToExecute.length) {
+      callback();
+    } else {
+      insertScriptsSequentially(scriptsToExecute, callback, index);
+    }
+  });
+}
+
+export function simulatePageLoad($container) {
+  let $scriptsRoot = document.querySelector('#scripts-root');
+  if (!$scriptsRoot) {
+    $scriptsRoot = document.createElement('div');
+    $scriptsRoot.id = 'scripts-root';
+    document.body.appendChild($scriptsRoot);
+  } else {
+    $scriptsRoot.innerHTML = '';
+  }
+  const $scripts = Array.from($container.querySelectorAll('script'));
+
+  if ($scripts.length) {
+    const scriptsToExecute = [];
+    $scripts.forEach(($script: any) => {
+      const typeAttr = $script.getAttribute('type');
+
+      // only run script tags without the type attribute
+      // or with a javascript mime attribute value
+      if (!typeAttr || !runScriptTypes.includes(typeAttr)) {
+        scriptsToExecute.push(callback => insertScript($script, callback, $scriptsRoot));
+      }
+    });
+
+    // insert the script tags sequentially
+    // to preserve execution order
+    insertScriptsSequentially(scriptsToExecute, simulateDOMContentLoaded, undefined);
+  }
+}

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -149,6 +149,7 @@ export default async function renderMain({
   showMain();
 
   if ((ROOT_ELEMENT && element instanceof Node !== false) || typeof element === TYPE_STRING) {
+    const elementType = typeof element;
     // Build the decoration tag so we can check it to prevent unnecessary rerenders
     const decorationElement = getDecorationElement(decorationTag, element);
     // Don't re-mount the element if it didn't change and neither did the story
@@ -157,12 +158,12 @@ export default async function renderMain({
       if (decorationTag) {
         ROOT_ELEMENT.appendChild(decorationElement);
         simulateDOMContentLoaded();
-      } else {
-        // eslint-disable-next-line no-unused-expressions
-        typeof element === TYPE_STRING
-          ? (ROOT_ELEMENT.innerHTML = element)
-          : ROOT_ELEMENT.appendChild(element);
+      } else if (elementType === TYPE_STRING) {
+        ROOT_ELEMENT.innerHTML = element;
         simulatePageLoad(ROOT_ELEMENT);
+      } else {
+        ROOT_ELEMENT.appendChild(element);
+        simulateDOMContentLoaded();
       }
     }
   } else {

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -1,9 +1,13 @@
 /* eslint-disable valid-typeof */
+// We need the default as Runtime,
+// or else the Runtime class doesn't get properly resolved
+/* eslint-disable import/no-named-default */
+import { default as Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
 import { document, Node, window } from 'global';
-import { Runtime, VDOMFactory } from '@adobe/htlengine/src/runtime/Runtime';
 import { RenderMainArgs, ShowErrorArgs, DecorationTag, AemMetadata } from './types/types';
 import ComponentLoader from './helpers/ComponentLoader';
 import ResourceResolver from './helpers/ResourceResolver';
+import { simulatePageLoad } from './helpers/simulate-pageload';
 
 const DIV_TAG = 'div';
 const TYPE_STRING = 'string';
@@ -158,6 +162,8 @@ export default async function renderMain({
           ? (ROOT_ELEMENT.innerHTML = element)
           : ROOT_ELEMENT.appendChild(element);
       }
+
+      simulatePageLoad(ROOT_ELEMENT);
     }
   } else {
     showError(getErrorMessage(selectedKind, selectedStory));

--- a/app/aem/src/client/preview/render.ts
+++ b/app/aem/src/client/preview/render.ts
@@ -7,7 +7,7 @@ import { document, Node, window } from 'global';
 import { RenderMainArgs, ShowErrorArgs, DecorationTag, AemMetadata } from './types/types';
 import ComponentLoader from './helpers/ComponentLoader';
 import ResourceResolver from './helpers/ResourceResolver';
-import { simulatePageLoad } from './helpers/simulate-pageload';
+import { simulatePageLoad, simulateDOMContentLoaded } from './helpers/simulate-pageload';
 
 const DIV_TAG = 'div';
 const TYPE_STRING = 'string';
@@ -156,14 +156,14 @@ export default async function renderMain({
       resetRoot();
       if (decorationTag) {
         ROOT_ELEMENT.appendChild(decorationElement);
+        simulateDOMContentLoaded();
       } else {
         // eslint-disable-next-line no-unused-expressions
         typeof element === TYPE_STRING
           ? (ROOT_ELEMENT.innerHTML = element)
           : ROOT_ELEMENT.appendChild(element);
+        simulatePageLoad(ROOT_ELEMENT);
       }
-
-      simulatePageLoad(ROOT_ELEMENT);
     }
   } else {
     showError(getErrorMessage(selectedKind, selectedStory));

--- a/cli/src/cmds/stories/story.ts
+++ b/cli/src/cmds/stories/story.ts
@@ -56,31 +56,32 @@ export async function createStory(args, config) {
     componentConfig.components = getDirectories(componentPath);
   }
 
-  componentConfig.hasStories = (
-    await prompts()
-  ).hasStories;
+  componentConfig.hasStories = (await prompts()).hasStories;
 
   error(componentConfig.hasStories, false);
 
   if (config.singleStory) {
     componentConfig.stories = (
-      await prompts([ {
+      await prompts([
+        {
           type: 'confirm',
           name: 'hasStories',
           message:
             'Would you like to add some initial stories? We will add the default empty story for you',
           initial: true,
-        }, {
-        type: prev => (!! prev ? 'list' : null),
-        name: 'stories',
-        message: 'Add a comma separated list of stories:',
-        separator: ',',
-        format: res => {
-          if (!res.length) return false;
-          // else return res.map( story => toCamelCase(story));
-          return res;
         },
-      }])
+        {
+          type: prev => (prev ? 'list' : null),
+          name: 'stories',
+          message: 'Add a comma separated list of stories:',
+          separator: ',',
+          format: res => {
+            if (!res.length) return false;
+            // else return res.map( story => toCamelCase(story));
+            return res;
+          },
+        },
+      ])
     ).stories;
   } else {
     componentConfig.stories = [];

--- a/examples/aem-kitchen-sink/components/accordion/accordion.html
+++ b/examples/aem-kitchen-sink/components/accordion/accordion.html
@@ -23,3 +23,9 @@
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
          data-sly-test="${(wcmmode.edit || wcmmode.preview) && accordion.items.size < 1}"></sly>
 </div>
+<script>
+    setTimeout(() => {
+        const button = document.querySelector('.cmp-accordion__button')
+        button.click();
+    }, 50);
+</script>

--- a/examples/aem-kitchen-sink/components/accordion/example_content.json
+++ b/examples/aem-kitchen-sink/components/accordion/example_content.json
@@ -7,7 +7,7 @@
     "item_1": {
       ":type": "components/text",
       "text": "Accordion Item 1",
-      "title": "Title 1",
+      "title": "Title 1 - Open",
       "textIsRich": true
     },
     "item_2": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5836,7 +5836,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -8266,7 +8266,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -10159,11 +10159,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -10172,32 +10167,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -10253,11 +10226,6 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
Issue: We are trying to simulate the AEM environment for rendering HTL and HTML strings. However, the SB environment does not accurately simulate that environment currently because of HMR and replacing the markup on the page. This PR aims to more accurately simulate page load in an AEM environment by executing script tags added to the page via innerHTML and also firing the DOMContentLoaded event on each render.

## What I did
Added new file for simulating page load. Updated render method to use it accordingly. Updated accordion.html to include inline JavaScript to open the first item in the accordion.

## How to test
View the [Accordion](http://localhost:9001/?path=/story/accordion--accordion) example. Also, testing with HTML strings would be useful too.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? Added.
- Does this need an update to the documentation? Perhaps

If your answer is yes to any of these, please make sure to include it in your PR.
