### PR TITLE
feat(compiler): support multiple project roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,20 @@ export default class Person extends GenericModel {
 </div>
 ```
 
+### Extending from other projects.
+
+Extending from other projects is mostly straight forward, just import the components and models accordingly.
+A 3rd party project might choose to deliberately export the list of components and models, so just import
+their definition. see the `examples/aem-core-components` and how they imported in `examples/aem-kitchen-sink`. 
+
+However, if the 3rd party projects use template references, the HTL compiler can't resolve them. So they need
+to be specified during build time. This is currently only possible by using the `AEMRegisterJcrRoot` function.
+See [aem-kitchen-sink/.storybook/main.js](./examples/aem-kitchen-sink/.storybook/main.js#L22).
+
+The `AEMRegisterJcrRoot` function can also be used, if your project's content root is not the project directory.
+See [aem-core-components/.storybook/main.js](./examples/aem-core-components/.storybook/main.js#L20).
+
+
 ### Contributing
 
 For more information about how to start contributing to this project, see our [contributing file](./CONTRIBUTING.md).

--- a/app/aem/package.json
+++ b/app/aem/package.json
@@ -34,7 +34,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@adobe/htlengine": "4.3.0",
+    "@adobe/htlengine": "4.4.0",
     "@storybook/addons": "6.0.0-alpha.2",
     "@storybook/client-api": "6.0.0-alpha.2",
     "@storybook/core": "6.0.0-alpha.2",
@@ -45,7 +45,7 @@
     "babel-loader": "^8.0.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "htl-loader": "2.0.0",
+    "htl-loader": "2.1.0",
     "regenerator-runtime": "^0.13.3",
     "typescript": "^3.7.5",
     "webpack": "^4.42.0",

--- a/app/aem/src/client/preview/decorators/decorators.ts
+++ b/app/aem/src/client/preview/decorators/decorators.ts
@@ -12,6 +12,7 @@ export const aemMetadata = (metadata: Partial<AemMetadata>) => async (storyFn: (
       components: [...(metadata.components || []), ...(storyMetadata.components || [])],
       decorationTag: metadata.decorationTag || storyMetadata.decorationTag || {},
       models: metadata.models || storyMetadata.models || {},
+      roots: metadata.roots || storyMetadata.roots || [],
     },
   };
 };

--- a/app/aem/src/client/preview/types/types.ts
+++ b/app/aem/src/client/preview/types/types.ts
@@ -24,6 +24,7 @@ export interface AemMetadata {
   components?: any[];
   decorationTag?: DecorationTag;
   models: any;
+  roots?: string[];
 }
 
 export interface RenderMainArgs {

--- a/app/aem/src/server/framework-preset-aem.ts
+++ b/app/aem/src/server/framework-preset-aem.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { Configuration } from 'webpack';
 import runtimeVariables from '../client/preview/helpers/runtime-variables';
+import { createTemplateLoader } from '@adobe/htlengine';
 
 const modGen = (baseDir, varName, id) => {
   // todo: only proxy the models that are actually defined as models.
@@ -8,6 +9,11 @@ const modGen = (baseDir, varName, id) => {
 };
 
 export function webpack(config: Configuration) {
+  const templateLoader = createTemplateLoader([
+    // todo: add story project root ???
+    // todo: add roots from AEM metadata ????
+  ]);
+
   return {
     ...config,
     module: {
@@ -24,6 +30,7 @@ export function webpack(config: Configuration) {
                 includeRuntime: false,
                 globalName: 'context',
                 runtimeVars: Object.keys(runtimeVariables()),
+                templateLoader,
               },
             },
           ],

--- a/app/aem/src/server/framework-preset-aem.ts
+++ b/app/aem/src/server/framework-preset-aem.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { Configuration } from 'webpack';
 import runtimeVariables from '../client/preview/helpers/runtime-variables';
 import { createTemplateLoader } from '@adobe/htlengine';
+import options from './options';
 
 const modGen = (baseDir, varName, id) => {
   // todo: only proxy the models that are actually defined as models.
@@ -9,10 +10,7 @@ const modGen = (baseDir, varName, id) => {
 };
 
 export function webpack(config: Configuration) {
-  const templateLoader = createTemplateLoader([
-    // todo: add story project root ???
-    // todo: add roots from AEM metadata ????
-  ]);
+  const templateLoader = createTemplateLoader(options.jcrRoots);
 
   return {
     ...config,

--- a/app/aem/src/server/options.ts
+++ b/app/aem/src/server/options.ts
@@ -1,8 +1,25 @@
 // tslint:disable-next-line: no-var-requires
 const packageJson = require('../../package.json');
 
+/**
+ * The following code exposes the global AEMRegisterJcrRoot function in order for components
+ * to be able to register their project roots.
+ */
+const jcrRoots = [];
+
+// todo: add current project's CWD as project root !?!
+
+global['AEMRegisterJcrRoot'] = (root) => {
+  if (Array.isArray(root)) {
+    jcrRoots.push(...root);
+  } else {
+    jcrRoots.push(root);
+  }
+};
+
 export default {
   packageJson,
   framework: 'aem',
   frameworkPresets: [require.resolve('./framework-preset-aem.js')],
+  jcrRoots,
 };

--- a/examples/aem-core-components/.storybook/main.js
+++ b/examples/aem-core-components/.storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: [
-    `../core/wcm/components/**/*.stories.*`,
+    `../jcr_root/apps/core/wcm/components/**/*.stories.*`,
   ],
   addons: [
     "@storybook/addon-docs",

--- a/examples/aem-core-components/.storybook/main.js
+++ b/examples/aem-core-components/.storybook/main.js
@@ -16,3 +16,5 @@ module.exports = {
     "@storybook/addon-viewport"
   ]
 };
+
+AEMRegisterJcrRoot(require('../config').jcrRoots);

--- a/examples/aem-core-components/.storybook/preview.js
+++ b/examples/aem-core-components/.storybook/preview.js
@@ -1,17 +1,10 @@
 import { addParameters, addDecorator } from '@storybook/client-api';
 import { withA11y } from '@storybook/addon-a11y';
 import { aemMetadata } from '@storybook/aem';
-import models from '../models';
+import meta from '..';
 
 addDecorator(withA11y);
-addDecorator(aemMetadata({
-  components: [
-    require('../core/wcm/components/accordion/v1/accordion/.content.xml'),
-    require('../core/wcm/components/list/v2/list/.content.xml'),
-    require('../core/wcm/components/text/v2/text/.content.xml'),
-  ],
-  models,
-}));
+addDecorator(aemMetadata(meta));
 
 addParameters({
   a11y: {

--- a/examples/aem-core-components/config.js
+++ b/examples/aem-core-components/config.js
@@ -1,0 +1,4 @@
+const path = require('path');
+module.exports = {
+  jcrRoots: path.resolve(__dirname, 'jcr_root'),
+}

--- a/examples/aem-core-components/index.js
+++ b/examples/aem-core-components/index.js
@@ -1,4 +1,7 @@
+const path = require('path');
+
 module.exports = {
   models: require('./models'),
   components: require('./components'),
+  roots: [ path.resolve(__dirname, 'jcr_root') ],
 };

--- a/examples/aem-core-components/index.js
+++ b/examples/aem-core-components/index.js
@@ -3,5 +3,4 @@ const path = require('path');
 module.exports = {
   models: require('./models'),
   components: require('./components'),
-  roots: [ path.resolve(__dirname, 'jcr_root') ],
 };

--- a/examples/aem-core-components/jcr_root/apps/core/wcm/components/list/v2/list/list.html
+++ b/examples/aem-core-components/jcr_root/apps/core/wcm/components/list/v2/list/list.html
@@ -1,7 +1,6 @@
-<!--/* todo: fix template resolution for extended components */-->
 <ul data-sly-use.list="com.adobe.cq.wcm.core.components.models.List"
     data-sly-list.item="${list.listItems}"
-    data-sly-use.template="../../../../../../core/wcm/components/commons/v1/templates.html"
+    data-sly-use.template="core/wcm/components/commons/v1/templates.html"
     data-sly-use.itemTemplate="item.html"
     class="cmp-list">
     <li class="cmp-list__item" data-sly-call="${itemTemplate.item @ list = list, item = item}"></li>

--- a/examples/aem-core-components/jcr_root/apps/core/wcm/components/text/v2/text/text.html
+++ b/examples/aem-core-components/jcr_root/apps/core/wcm/components/text/v2/text/text.html
@@ -1,5 +1,5 @@
 <div data-sly-use.textModel="com.adobe.cq.wcm.core.components.models.Text"
-     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.text="${textModel.text}"
      class="cmp-text">
     <p class="cmp-text__paragraph"

--- a/examples/aem-core-components/jcr_root/apps/core/wcm/components/text/v2/text/text.html
+++ b/examples/aem-core-components/jcr_root/apps/core/wcm/components/text/v2/text/text.html
@@ -1,6 +1,5 @@
-<!--/* todo: fix template resolution for extended components */-->
 <div data-sly-use.textModel="com.adobe.cq.wcm.core.components.models.Text"
-     data-sly-use.templates="../../../../../../core/wcm/components/commons/v1/templates.html"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test.text="${textModel.text}"
      class="cmp-text">
     <p class="cmp-text__paragraph"

--- a/examples/aem-kitchen-sink/.storybook/main.js
+++ b/examples/aem-kitchen-sink/.storybook/main.js
@@ -17,3 +17,6 @@ module.exports = {
     "@storybook/addon-viewport"
   ]
 };
+
+// need to specify the additional jcrRoots from dependencies
+AEMRegisterJcrRoot(require('@adobe/aem-core-components-storified/config').jcrRoots);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@adobe/htlengine@4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.3.0.tgz#fd10240b667cf1ad0643912974c9f61edef3d216"
-  integrity sha512-t9YmYRXgfZv/b9jEUsVa/kOseXYm+2G8hD0yxAgWt0E0hkE66NXe0E2JZFXDnz7Cebx9wsn0Xm+1qJeealsKxQ==
+"@adobe/htlengine@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@adobe/htlengine/-/htlengine-4.4.0.tgz#8449031ac055c41c1ad6e251729757538d48558b"
+  integrity sha512-ea9gu86jXwmxhk5Dj9lZ0A61PhaaSRQjx3RITIVLPlPSMgEGWdAmi/9wenE10N52FhamAjHTILJa0OCwtm3hnQ==
   dependencies:
     antlr4 "^4.7.2"
-    fs-extra "^8.0.0"
+    fs-extra "^9.0.0"
     he "^1.2.0"
     lodash "^4.17.15"
     moment "^2.24.0"
@@ -17,7 +17,7 @@
     rehype-parse "^6.0.1"
     sanitizer "^0.1.3"
     source-map "^0.7.3"
-    unified "^8.0.0"
+    unified "^9.0.0"
     urijs "^1.19.1"
     xregexp "^4.2.4"
 
@@ -3880,6 +3880,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob-lite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
@@ -7344,7 +7349,7 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
+fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -7352,6 +7357,16 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -8021,10 +8036,10 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.7.1, hosted-git-info@^2.8.8:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
-htl-loader@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/htl-loader/-/htl-loader-2.0.0.tgz#91e8a0eee0bf2b1285299d03e21df857351e870c"
-  integrity sha512-fRoZEjdKiIUau84o+Snz0PJqaUpSnBrQEkMnRzABL/kcG9Vys5gJhNy+9uI6YhTcREaSN8UlcFi/mOBBX9vCoQ==
+htl-loader@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/htl-loader/-/htl-loader-2.1.0.tgz#c210d7e13a5a53f9732a0b94439a7e3ba86db3cf"
+  integrity sha512-6bttCydhby2eKSGg7XfZOiyao5LP7BuEV+7+ClA270B8/WabrU51dUmfkLfDLHM94cCKOjsahQLY0nMVkTt6Mw==
   dependencies:
     loader-utils "^1.2.3"
 
@@ -9706,6 +9721,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -15512,13 +15536,25 @@ unified-message-control@^1.0.0:
     unist-util-visit "^1.0.0"
     vfile-location "^2.0.0"
 
-unified@8.4.2, unified@^8.0.0, unified@^8.2.0:
+unified@8.4.2, unified@^8.2.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.2.tgz#13ad58b4a437faa2751a4a4c6a16f680c500fff1"
   integrity sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
+unified@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.0.0.tgz#12b099f97ee8b36792dbad13d278ee2f696eed1d"
+  integrity sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
     is-plain-obj "^2.0.0"
     trough "^1.0.0"
     vfile "^4.0.0"
@@ -15661,6 +15697,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
fixes: #92

## What I did

- added mechanism for libraries to export their project roots (jcr_root)
- added workaround via global function (`AEMRegisterJcrRoot`) that can be used in `main.js`
